### PR TITLE
Fixed setup.py to support all python versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,10 +18,10 @@
 
 import os
 import sys
-if sys.version < (2, 6):
+if sys.version_info < (2, 6):
     from distutils.command import register
 
-    def isstr((k, v)):
+    def isstr(k, v):
         return isinstance(v, basestring)
 
     def patch(func):


### PR DESCRIPTION
`pip install kmodpy` was broken on python3 because [tuple parameter unpacking is not supported anymore](https://www.python.org/dev/peps/pep-3113/). 